### PR TITLE
11-03 Meaning of time stamp: fix definitions of 'beginning' and 'end'

### DIFF
--- a/tables_en/11-03.csv
+++ b/tables_en/11-03.csv
@@ -1,6 +1,6 @@
 notation,name,description
 beginning,Beginning,Time stamps indicate the beginning of a period covering the range up to but excluding the following time stamp.
-end,End,Time stamps indicate the end of a period covering the range up to but excluding the preceding time stamp.
+end,End,Time stamps indicate the end of a period covering the range back to but excluding the preceding time stamp.
 inapplicable,inapplicable,None of the codes in the table are applicable in the context of this particular observation.
 middle,Middle,Time stamps indicate the middle of a period beginning at the middle of the range described by this and the preceding time stamp and ending right before the middle of the range described by this and the following time stamp.
 unknown,unknown,The beginning and end of the period described by the timestamp are unknown.

--- a/tables_en/11-03.csv
+++ b/tables_en/11-03.csv
@@ -1,6 +1,6 @@
 notation,name,description
-beginning,Beginning,Time stamps indicate the end of a period covering the range up to but excluding the preceding time stamp
-end,End,Time stamps indicate the middle of a period beginning at the middle of the range described by this and the preceding time stamp and ending right before the middle of the range described by this and the following time stamp.
+beginning,Beginning,Time stamps indicate the beginning of a period covering the range up to but excluding the following time stamp.
+end,End,Time stamps indicate the end of a period covering the range up to but excluding the preceding time stamp.
 inapplicable,inapplicable,None of the codes in the table are applicable in the context of this particular observation.
 middle,Middle,Time stamps indicate the middle of a period beginning at the middle of the range described by this and the preceding time stamp and ending right before the middle of the range described by this and the following time stamp.
 unknown,unknown,The beginning and end of the period described by the timestamp are unknown.


### PR DESCRIPTION
The definition of `beginning` reads as `end`, and `end` is a duplicate of `middle`. The problem traces back to the approved text from [CBS-16](https://library.wmo.int/doc_num.php?explnum_id=3505) page 717.

Reported by @iosifescu in https://github.com/EnviDat/monitoring-backend/issues/2#issuecomment-704560983