### PR TITLE
docstrings and test register exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ Published code tables can be found at WMO Codes Registry for WIGOS Metadata Repr
   Part D – Representations derived from data models
   See chapter FM 241: WMDR
 
+## Testing and management
+
+./scripts provides tools written in Python to check content consistency with the published test and prod registers and to upload changes.
+
+example usage:
+
+consistency check
+
+```
+tmode=test outfile=</path/to/writeable/file> python3 -m scripts.check_urls
+```
+
+upload change
+
+```
+python3 -m scripts.uploadChanges <uname> <temporaryKey> test </path/to/a/readable/file>
+```

--- a/scripts/uploadChanges.py
+++ b/scripts/uploadChanges.py
@@ -11,8 +11,10 @@ This script uploads content to the defined register
 This reqires an authentication token and userID and structured
 content.
 
-The structured content is taken from the command line argument which
-shall consist of a dictionary with the keys:
+The structured content is taken from the command line positional argument
+uploads
+which may either consist of a path to a JSON encoded file or an explicit JSON string
+The JSON payload shall be a dictionary with the keys:
   'PUT', 'POST'
 and each key shall provide a list of .ttl files to upload to prodRegister
 based on the relative path of the .ttl file.
@@ -37,6 +39,7 @@ def parse_uploads(uploads):
     return result
 
 def post(session, url, payload):
+    # POST new content to the intended parent register
     headers={'Content-type':'text/turtle; charset=UTF-8'}
     response = session.get(url, headers=headers)
     #if response.status_code != 200:
@@ -48,6 +51,7 @@ def post(session, url, payload):
         print('POST failed with {}\n{}'.format(res.status_code, res.reason))
 
 def put(session, url, payload):
+    # PUT updated content to the entity already registered
     headers={'Content-type':'text/turtle; charset=UTF-8'}
     response = session.get(url, headers=headers)
     if response.status_code != 200:


### PR DESCRIPTION
I have updated some docstrings for the scripts and added a small number of test exceptions.

The test exceptions are targeting the test registry, which has accrued some content oddities that i have not been able to resolve.  There are minor issues in the data store on testwmocodes.metarelate.net which will need careful debug analysis and cleansing, which I have not been able to deliver, hence these temporary work arounds in 3 test cases.

There are no work arounds on Prod, which is fully consistent with the content generation

If this PR is merged, then processed `ttl` RDF encoded content will be added to the repository by the merge to master.  If this behaviour is not desired, please request a change to the PR github action work flow