### PR TITLE
increase python version to 3.10 for actions

### DIFF
--- a/.github/workflows/check_consistency.yml
+++ b/.github/workflows/check_consistency.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: ['3.10']
         test-mode: [test, prod]
 
     steps:

--- a/.github/workflows/generateTTLandCommit.yml
+++ b/.github/workflows/generateTTLandCommit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: ['3.10']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
@amilan17 

it looks like github have deprecated the python version used in the github actions

the docs recommend always setting this, for consistency, so this is a change that requires occasional management
https://github.com/marketplace/actions/setup-python

i have proposed '3.10' taking the suggested default from the github docs