### PR TITLE
update branch for issue #391

### DIFF
--- a/tables_en/1-01-01.csv
+++ b/tables_en/1-01-01.csv
@@ -47,10 +47,10 @@ notation,path,domains,tags,name,description
 253,\Atmosphere\Humidity,,,Mass mixing ratio,
 254,\Atmosphere\Humidity,,,Object wetness duration,
 255,\Atmosphere\Humidity,,,Water vapour pressure,
-257,\Atmosphere\Lightning,,,Lightning discharge energy,
-258,\Atmosphere\Lightning,,,Lightning discharge polarity,
-259,\Atmosphere\Lightning,,,Lightning discharge rates,
-260,\Atmosphere\Lightning,,,"Lightning discharge type (cloud to cloud, cloud to surface)",
+257,\Atmosphere\Lightning,,,Lightning discharge current,Current incurred by the lightning discharge.
+258,\Atmosphere\Lightning,,,Lightning discharge polarity,Polarity of the charge effectively lowered to ground during a lightning discharge.
+259,\Atmosphere\Lightning,,,Lightning discharge rates,"Number of lightning discharges per unit time in a given region (e.g. world-wide) or for a given storm system (e.g. a thunderstorm cell)."
+260,\Atmosphere\Lightning,,,"Lightning discharge type (cloud to cloud, cloud to surface)","Lightning discharge type, defined by the path of the lightning discharge: between two clouds or the same cloud (intra-cloud) or between cloud and ground (cloud-to-ground)."
 265,\Atmosphere,,,Past weather,"Predominant characteristic of weather which had existed at the station during a given period of time. [Manual on Codes (WMO-No. 306), Volume I.1. 2011 edition updated in 2019.]"
 266,\Atmosphere,,,Present weather,"Weather existing at the time of observation, or under certain conditions, during the hour preceding the time of observation. [Manual on Codes (WMO-No. 306), Volume I.1. 2011 edition updated in 2019.]"
 267,\Atmosphere\Radiation,,,Background luminance,Luminous flux received from the background per unit solid angle and per unit area. Note: Luminous flux is a quantity derived from radiant flux by evaluating the radiation according to its action upon the International Commission on Illumination standard photometric observer.
@@ -165,8 +165,8 @@ notation,path,domains,tags,name,description
 429,\Atmosphere\Gas phase\Reactive Gas\Sulfur containing compounds,,,CS2 (carbon disulfide),"IUPAC: methanedithione, PubChem CID: 6348, CAS Number: 75-15-0, in gas phase"
 430,\Atmosphere\Gas phase\Reactive Gas\Sulfur containing compounds,,,SO2,"IUPAC: sulfur dioxide, PubChem CID: 1119, CAS Number: 7446 09-5, in gas phase"
 431,\Atmosphere\Lightning\Position,,,Lightning detection (time and location),"Detection of the time and location (latitude, longitude) of lightning events. Accuracy expressed in terms of Hit Rate and False Alarm Rate, which requires predetermination of a specific distance and time tolerance."
-432,\Atmosphere\Lightning\Position,,,Lightning direction from station,
-433,\Atmosphere\Lightning\Position,,,Lightning distance from station,
+432,\Atmosphere\Lightning\Position,,,Lightning discharge direction from station,"Azimuth of the lightning event with respect to the corresponding station."
+433,\Atmosphere\Lightning\Position,,,Lightning discharge distance from station,"Distance of the lightning event from the corresponding station."
 434,\Atmosphere\Gas phase\Reactive Gas\VOC,,,"C2H2 (ethyne, acetylene)","IUPAC: acetylene, PubChem CID: 6326, CAS Number: 74-86-2, in gas phase"
 435,\Atmosphere\Gas phase\Reactive Gas\VOC,,,"C2H2O2 (oxaldehyde, ethanedial)","IUPAC: oxaldehyde, PubChem CID: 7860, CAS Number: 107-22-2, in gas phase"
 436,\Atmosphere\Gas phase\Reactive Gas\VOC,,,C2H4 (ethene),"IUPAC: ethene, PubChem CID: 6325, CAS Number: 74-85-1, in gas phase"
@@ -424,8 +424,8 @@ notation,path,domains,tags,name,description
 727,\Atmosphere\Particle phase\Physical properties,,"particle phase, physical properties",Dust mass concentration,Concentration of dust or sand in the atmosphere
 728,\Atmosphere\Particle phase\Physical properties,,"particle phase, physical properties",Volcanic ash particle mass concentration,3D field of mass mixing ratio of volcanic ash
 729,\Atmosphere\Particle phase\Physical properties,,"particle phase, physical properties",Aerosol volcanic ash (Total column),Field of total column mass of volcanic ash
-12001,\Atmosphere\Lightning,,,Total lightning density,
-12002,\Atmosphere\Lightning,,,Lightning density cloud-to-ground,
+12001,\Atmosphere\Lightning,,,Total lightning flash density,"Total number of detected flashes in the corresponding time interval and space unit. Note: The space unit (grid box) should be equal to the horizontal resolution and the accumulation time to the observing cycle."
+12002,\Atmosphere\Lightning,,,Lightning flash density cloud-to-ground,"Number of detected cloud-to-ground flashes in the corresponding time interval and space unit. "
 12005,\Atmosphere\Wind,,,Horizontal wind direction at specified distance from reference surface,"The direction of horizontal wind expressed in degrees at which the wind originates. This scalar quantity can be used to represent a value at a given location and an instantaneous time or average over spatio-temporal extent or values as a function of spatio-temporal coordinates. Note: 1) Wind direction is coded as 00 under ""Calm"" conditions at which the average wind speed is less than or equal to 0.2 m/s (< 1 kt). The direction in this case is coded as 00; 2) Wind direction at stations within 1 degree of the North Pole or 1 degree of the South Pole should be measured so that the azimuth ring should be aligned with its zero coinciding with the Greenwich 0 degree meridian."
 12006,\Atmosphere\Wind,,,Horizontal wind speed at specified distance from reference surface,"Commonly refers to the speed of horizontal wind, a ratio of the horizontal distance covered by the air to the time taken to cover that distance. This scalar quantity can be used to represent a value at a given location and an instantaneous time or average over spatio-temporal extent or values as a function of spatio-temporal coordinates."
 12016,\Atmosphere\Gas phase\Greenhouse Gas\CFCs,,,"Cl3CCF3 (1,1,1-trichloro-2,2,2-trifluoroethane, CFC-113a)","IUPAC: 1,1,1-trichloro-2,2,2-trifluoroethane, PubChem CID: 9635, CAS Number: 354-58-5, in gas phase"

--- a/wmdr/ObservedVariableAtmosphere/12001.ttl
+++ b/wmdr/ObservedVariableAtmosphere/12001.ttl
@@ -3,6 +3,6 @@
 @prefix dct: <http://purl.org/dc/terms/> . 
 
 <12001> a skos:Concept ;
-	rdfs:label "Total lightning density" ;
+	rdfs:label "Total lightning flash density" ;
 	skos:notation "12001" ;
-	dct:description ""@en	.
+	dct:description "Total number of detected flashes in the corresponding time interval and space unit. Note: The space unit (grid box) should be equal to the horizontal resolution and the accumulation time to the observing cycle."@en	.

--- a/wmdr/ObservedVariableAtmosphere/12002.ttl
+++ b/wmdr/ObservedVariableAtmosphere/12002.ttl
@@ -3,6 +3,6 @@
 @prefix dct: <http://purl.org/dc/terms/> . 
 
 <12002> a skos:Concept ;
-	rdfs:label "Lightning density cloud-to-ground" ;
+	rdfs:label "Lightning flash density cloud-to-ground" ;
 	skos:notation "12002" ;
-	dct:description ""@en	.
+	dct:description "Number of detected cloud-to-ground flashes in the corresponding time interval and space unit."@en	.

--- a/wmdr/ObservedVariableAtmosphere/257.ttl
+++ b/wmdr/ObservedVariableAtmosphere/257.ttl
@@ -3,6 +3,6 @@
 @prefix dct: <http://purl.org/dc/terms/> . 
 
 <257> a skos:Concept ;
-	rdfs:label "Lightning discharge energy" ;
+	rdfs:label "Lightning discharge current" ;
 	skos:notation "257" ;
-	dct:description ""@en	.
+	dct:description "Current incurred by the lightning discharge."@en	.

--- a/wmdr/ObservedVariableAtmosphere/258.ttl
+++ b/wmdr/ObservedVariableAtmosphere/258.ttl
@@ -5,4 +5,4 @@
 <258> a skos:Concept ;
 	rdfs:label "Lightning discharge polarity" ;
 	skos:notation "258" ;
-	dct:description ""@en	.
+	dct:description "Polarity of the charge effectively lowered to ground during a lightning discharge."@en	.

--- a/wmdr/ObservedVariableAtmosphere/259.ttl
+++ b/wmdr/ObservedVariableAtmosphere/259.ttl
@@ -5,4 +5,4 @@
 <259> a skos:Concept ;
 	rdfs:label "Lightning discharge rates" ;
 	skos:notation "259" ;
-	dct:description ""@en	.
+	dct:description "Number of lightning discharges per unit time in a given region (e.g. world-wide) or for a given storm system (e.g. a thunderstorm cell)."@en	.

--- a/wmdr/ObservedVariableAtmosphere/260.ttl
+++ b/wmdr/ObservedVariableAtmosphere/260.ttl
@@ -5,4 +5,4 @@
 <260> a skos:Concept ;
 	rdfs:label "Lightning discharge type (cloud to cloud, cloud to surface)" ;
 	skos:notation "260" ;
-	dct:description ""@en	.
+	dct:description "Lightning discharge type, defined by the path of the lightning discharge: between two clouds or the same cloud (intra-cloud) or between cloud and ground (cloud-to-ground)."@en	.

--- a/wmdr/ObservedVariableAtmosphere/432.ttl
+++ b/wmdr/ObservedVariableAtmosphere/432.ttl
@@ -3,6 +3,6 @@
 @prefix dct: <http://purl.org/dc/terms/> . 
 
 <432> a skos:Concept ;
-	rdfs:label "Lightning direction from station" ;
+	rdfs:label "Lightning discharge direction from station" ;
 	skos:notation "432" ;
-	dct:description ""@en	.
+	dct:description "Azimuth of the lightning event with respect to the corresponding station."@en	.

--- a/wmdr/ObservedVariableAtmosphere/433.ttl
+++ b/wmdr/ObservedVariableAtmosphere/433.ttl
@@ -3,6 +3,6 @@
 @prefix dct: <http://purl.org/dc/terms/> . 
 
 <433> a skos:Concept ;
-	rdfs:label "Lightning distance from station" ;
+	rdfs:label "Lightning discharge distance from station" ;
 	skos:notation "433" ;
-	dct:description ""@en	.
+	dct:description "Distance of the lightning event from the corresponding station."@en	.


### PR DESCRIPTION
For 432 and 433, the new name includes the word 'discharge', which is not found in the issue. I cannot really judge the significance of this, but it seems minor.
For 12001 and 12002, the parentheses around the word 'flash' are not included in the name, unlike found in the issue. This is insignificant.